### PR TITLE
Feat: toggle component 구현 (#9)

### DIFF
--- a/Projects/App/Sources/Screens/Home/HomeViewController.swift
+++ b/Projects/App/Sources/Screens/Home/HomeViewController.swift
@@ -8,6 +8,10 @@
 
 import UIKit
 
+import DesignSystem
+
 class HomeViewController: UIViewController {
+
+    let toggle: WKToggle = WKToggle()
 
 }

--- a/Projects/App/Sources/Screens/Home/HomeViewController.swift
+++ b/Projects/App/Sources/Screens/Home/HomeViewController.swift
@@ -8,10 +8,6 @@
 
 import UIKit
 
-import DesignSystem
-
 class HomeViewController: UIViewController {
-
-    let toggle: WKToggle = WKToggle()
-
+    
 }

--- a/Projects/App/Sources/Screens/Home/WKToggle.swift
+++ b/Projects/App/Sources/Screens/Home/WKToggle.swift
@@ -10,6 +10,12 @@ import UIKit
 
 import SnapKit
 
+// MARK: - Protocols
+
+protocol WKToggleDelegate: AnyObject {
+    func toggleStateChanged(_ toggle: WKToggle, isOn: Bool)
+}
+
 class WKToggle: UIView {
 
     enum Number {
@@ -37,7 +43,8 @@ class WKToggle: UIView {
     // MARK: - Properties
 
     private var isOn: Bool = true
-    
+    weak var delegate: WKToggleDelegate?
+
     // MARK: - Initializer
 
     override init(frame: CGRect) {
@@ -60,6 +67,7 @@ class WKToggle: UIView {
     private func toggleDidTap(sender: UITapGestureRecognizer) {
         self.isOn.toggle()
         self.isOn ? self.turnOn() : self.turnOff()
+        self.delegate?.toggleStateChanged(self, isOn: self.isOn)
     }
 
     // MARK: - Methods

--- a/Projects/App/Sources/Screens/Home/WKToggle.swift
+++ b/Projects/App/Sources/Screens/Home/WKToggle.swift
@@ -1,0 +1,134 @@
+//
+//  WKToggle.swift
+//  App
+//
+//  Created by 윤예지 on 2022/11/19.
+//  Copyright © 2022 com.workit. All rights reserved.
+//
+
+import UIKit
+
+import SnapKit
+
+class WKToggle: UIView {
+
+    enum Number {
+        static let circleInnerPadding: CGFloat = 2
+        static let circleWidthHeight: CGFloat = 24
+        static let containerWidth: CGFloat = 49
+        static let containerHeight: CGFloat = 28
+        static let duration: CGFloat = 0.2
+    }
+
+    // MARK: - UIComponents
+
+    private let containerView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .purple
+        return view
+    }()
+
+    private let circleView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .white
+        return view
+    }()
+
+    // MARK: - Properties
+
+    private var isOn: Bool = true
+    
+    // MARK: - Initializer
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setViewHierchy()
+        setDefaultConstraints()
+        setLayout()
+        makeViewRounded()
+        setClickEvent()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - Actions
+
+    @objc
+    private func toggleDidTap(sender: UITapGestureRecognizer) {
+        self.isOn.toggle()
+        self.isOn ? self.turnOn() : self.turnOff()
+    }
+
+    // MARK: - Methods
+
+    private func setViewHierchy() {
+        self.addSubview(containerView)
+        self.containerView.addSubview(circleView)
+    }
+
+    private func setDefaultConstraints() {
+        self.snp.makeConstraints { make in
+            make.width.equalTo(Number.containerWidth)
+            make.height.equalTo(Number.containerHeight)
+        }
+    }
+
+    private func setLayout() {
+        self.containerView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+
+        self.circleView.snp.makeConstraints { make in
+            make.top.trailing.bottom.equalToSuperview().inset(Number.circleInnerPadding)
+            make.width.height.equalTo(Number.circleWidthHeight)
+        }
+    }
+
+    private func makeViewRounded() {
+        self.makeRounded(radius: Number.containerHeight / 2)
+        self.circleView.makeRounded(radius: Number.circleWidthHeight / 2)
+    }
+
+    private func setClickEvent() {
+        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(toggleDidTap(sender:)))
+        self.addGestureRecognizer(tapGesture)
+    }
+
+    private func turnOn() {
+        self.circleView.snp.remakeConstraints { make in
+            make.top.trailing.bottom.equalToSuperview().inset(Number.circleInnerPadding)
+            make.width.height.equalTo(Number.circleWidthHeight)
+        }
+
+        UIView.animate(withDuration: 0.2) {
+            self.layoutIfNeeded()
+            self.containerView.backgroundColor = .purple
+        }
+    }
+
+    private func turnOff() {
+        self.circleView.snp.remakeConstraints { make in
+            make.top.leading.bottom.equalToSuperview().inset(Number.circleInnerPadding)
+            make.width.height.equalTo(Number.circleWidthHeight)
+        }
+
+        UIView.animate(withDuration: Number.duration) {
+            self.layoutIfNeeded()
+            self.containerView.backgroundColor = .gray
+        }
+    }
+
+}
+
+// TODO: - Global 모듈로 이동
+extension UIView {
+
+    func makeRounded(radius: CGFloat) {
+        self.clipsToBounds = true
+        self.layer.cornerRadius = radius
+    }
+
+}

--- a/Projects/DesignSystem/Sources/UIComponents/Toggles/WKToggle.swift
+++ b/Projects/DesignSystem/Sources/UIComponents/Toggles/WKToggle.swift
@@ -60,13 +60,17 @@ class WKToggle: UIView {
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
-    
+
     // MARK: - Actions
 
     @objc
     private func toggleDidTap(sender: UITapGestureRecognizer) {
         self.isOn.toggle()
-        self.isOn ? self.turnOn() : self.turnOff()
+        if self.isOn {
+            self.turnOn()
+        } else {
+            self.turnOff()
+        }
         self.delegate?.toggleStateChanged(self, isOn: self.isOn)
     }
 

--- a/Projects/DesignSystem/Sources/UIComponents/Toggles/WKToggle.swift
+++ b/Projects/DesignSystem/Sources/UIComponents/Toggles/WKToggle.swift
@@ -16,7 +16,7 @@ protocol WKToggleDelegate: AnyObject {
     func toggleStateChanged(_ toggle: WKToggle, isOn: Bool)
 }
 
-class WKToggle: UIView {
+public class WKToggle: UIView {
 
     enum Number {
         static let circleInnerPadding: CGFloat = 2


### PR DESCRIPTION
## 관련 이슈
- Resolved: #9 

## 작업 내용
- 토글 컴포넌트를 구현했습니다. 기본 UISwitch는 사이즈 변경 등에 제약이 많아서 직접 구현했어요
- iOS 내에서는 Switch 란 네이밍이지만 저희 디자인 시스템에서는 Toggle 이기 때문에 Toggle로 네이밍 해주었습니다.
- 아직 에셋이 추가되지 않아서 시스템 컬러를 사용했습니다.
- 후순위로 밀린 컴포넌트인지라 일단 색깔을 바꾸거나 사이즈를 변경하는 등의 옵션 함수들은 구현하지 않았어요
- UIControl 을 상속해서 구현하고 싶었는데 잘 안돼서, 일단 UIView를 써서 탭제스처를 달았습니다 -.-..
- 파일 내에 같이 구현되어있는 프로토콜과 익스텐션은 Global 모듈이 생기면 이동하도록 할게요

### 사용법

```Swift
class HomeViewController: UIViewController {

    lazy var toggle: WKToggle = {
        let toggle = WKToggle()
        toggle.delegate = self
        return toggle
    }()

    override func viewDidLoad() {
        view.addSubview(toggle)
        toggle.snp.makeConstraints { make in
            make.center.equalToSuperview()
        }
    }

}

extension HomeViewController: WKToggleDelegate {

    func toggleStateChanged(_ toggle: WKToggle, isOn: Bool) {
        // todo anything ~~
    }

}
```



## 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->

https://user-images.githubusercontent.com/69361613/203006104-613f2405-a563-40d3-88ca-b25f0c03b9ca.mov


