### PR TITLE
Feat: WKSelectableTextField 구현

### DIFF
--- a/Projects/DesignSystem/Sources/UIComponents/WKDateTextField.swift
+++ b/Projects/DesignSystem/Sources/UIComponents/WKDateTextField.swift
@@ -11,12 +11,11 @@ import UIKit
 import RxSwift
 import SnapKit
 
-public final class WKDateTextField: WKTextField {
+public final class WKDateTextField: WKSelectableTextField {
     
     // MARK: UIComponenets
     
     private let calendarImageView: UIImageView = UIImageView(image: Image.wkCalendar.withRenderingMode(.alwaysOriginal))
-    private let button: UIButton = UIButton(type: .system)
     
     // MARK: Initializer
     
@@ -38,10 +37,6 @@ public final class WKDateTextField: WKTextField {
         let dateString: String = dateFormatter.string(from: date)
         self.text = dateString
     }
-    
-    public func setAction(_ closure: @escaping () -> Void) {
-        self.button.addAction( UIAction { _ in closure() }, for: .touchUpInside)
-    }
 }
 
 // MARK: - UI
@@ -49,16 +44,12 @@ public final class WKDateTextField: WKTextField {
 extension WKDateTextField {
     private func setDefaultLayout() {
         self.removeClearButton()
-        self.addSubviews([calendarImageView, button])
+        self.addSubviews([calendarImageView])
         
         self.calendarImageView.snp.makeConstraints { make in
             make.centerY.equalToSuperview()
             make.top.bottom.trailing.equalToSuperview().inset(12)
             make.width.equalTo(calendarImageView.snp.height)
-        }
-        
-        self.button.snp.makeConstraints { make in
-            make.edges.equalToSuperview()
         }
     }
 }

--- a/Projects/DesignSystem/Sources/UIComponents/WKDateTextField.swift
+++ b/Projects/DesignSystem/Sources/UIComponents/WKDateTextField.swift
@@ -44,7 +44,7 @@ public final class WKDateTextField: WKSelectableTextField {
 extension WKDateTextField {
     private func setDefaultLayout() {
         self.removeClearButton()
-        self.addSubviews([calendarImageView])
+        self.addSubview(calendarImageView)
         
         self.calendarImageView.snp.makeConstraints { make in
             make.centerY.equalToSuperview()

--- a/Projects/DesignSystem/Sources/UIComponents/WKSelectableTextField.swift
+++ b/Projects/DesignSystem/Sources/UIComponents/WKSelectableTextField.swift
@@ -1,0 +1,50 @@
+//
+//  WKSelectableTextField.swift
+//  DesignSystem
+//
+//  Created by madilyn on 2022/11/25.
+//  Copyright © 2022 com.workit. All rights reserved.
+//
+
+import UIKit
+
+import RxCocoa
+import RxSwift
+import SnapKit
+
+public class WKSelectableTextField: WKTextField {
+    
+    // MARK: UIComponents
+    
+    private let button: UIButton = UIButton(type: .system)
+    
+    // MARK: Initializer
+    
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        self.setDefaultLayout()
+    }
+    
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+    }
+    
+    // MARK: - Methods
+    
+    public func setAction(_ closure: @escaping () -> Void) {
+        self.button.addAction( UIAction { _ in closure() }, for: .touchUpInside)
+    }
+}
+
+// MARK: - UI
+
+extension WKSelectableTextField {
+    private func setDefaultLayout() {
+        self.removeClearButton()
+        self.addSubview(button)
+        
+        self.button.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- Resolved: #21

## 작업 내용
- WKSelectableTextField를 구현하였습니다.
- WKSelectableTextField에 캘린더 이미지 + 날짜 세팅 함수가 추가된 게 이전 PR(#20)에서 구현했던 WKDateTextField라서, WKDateTextField가 WKSelectableTextField를 상속받도록 변경하였습니다.
### 사용법
```
        selectableTextField.setAction { [weak self] in
            debugPrint("selectableTextField")
        }
        
        selectableTextField.placeholder = "프로젝트명을 입력해 주세요."
```
## 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->
<img width="333" alt="스크린샷 2022-11-28 오후 4 26 19" src="https://user-images.githubusercontent.com/43312096/204218234-f37a925b-86a5-4708-b04a-c41a3a32526d.png">



<!-- 아 맞다! Assignee, Reviewer, Label 설정! 😇 -->
