### PR TITLE
Chore: 기록하기 캘린더 바텀시트 구현 및 취소 구현

### DIFF
--- a/Projects/App/Sources/Screens/CalendarBottomSheet/CalendarBottomSheetViewController.swift
+++ b/Projects/App/Sources/Screens/CalendarBottomSheet/CalendarBottomSheetViewController.swift
@@ -320,3 +320,5 @@ extension CalendarItemViewRepresentable {
         CalendarItemModel<Self>(invariantViewProperties: invariantViewProperties, viewModel: viewModel)
     }
 }
+
+// swiftlint:enable function_body_length

--- a/Projects/App/Sources/Screens/CalendarBottomSheet/SingleDayCalendarBottomSheetViewController.swift
+++ b/Projects/App/Sources/Screens/CalendarBottomSheet/SingleDayCalendarBottomSheetViewController.swift
@@ -1,0 +1,238 @@
+//
+//  SingleDayCalendarBottomSheetViewController.swift
+//  App
+//
+//  Created by madilyn on 2023/04/06.
+//  Copyright © 2023 com.workit. All rights reserved.
+//
+
+import DesignSystem
+import UIKit
+
+import HorizonCalendar
+import RxSwift
+import SnapKit
+
+// swiftlint:type_name
+
+protocol SingleDayCalendarBottomSheetDelegate: AnyObject {
+    func sendSelectedSingleDay(_ date: Date)
+}
+
+final class SingleDayCalendarBottomSheetViewController: BaseViewController {
+    
+    enum Text {
+        static let okMessage = "확인"
+        static let reset = "초기화"
+    }
+    
+    // MARK: - UIComponenets
+    
+    private let bottomView: UIView = {
+        let view: UIView = UIView()
+        view.makeRounded(radius: 12)
+        view.backgroundColor = .wkWhite
+        return view
+    }()
+    
+    private let okButton: WKRoundedButton = {
+        let button = WKRoundedButton()
+        button.setTitle(Text.okMessage, for: .normal)
+        button.setEnabledColor(color: .wkMainNavy)
+        return button
+    }()
+    
+    private let resetButton: UIButton = {
+        let button = UIButton()
+        button.setTitle(Text.reset, for: .normal)
+        button.setImage(Image.wkReset, for: .normal)
+        button.setTitleColor(.wkBlack, for: .normal)
+        button.titleLabel?.font = .b1M
+        return button
+    }()
+    
+    lazy var calendarView = CalendarView(initialContent: makeContent())
+    
+    // MARK: - Properties
+    
+    weak var delegate: SingleDayCalendarBottomSheetDelegate?
+    
+    private let dateSelectPublisher = PublishSubject<(CalendarSelection?)>()
+    private let disposeBag = DisposeBag()
+    private var selectedDay: Day?
+    
+    lazy var calendar = Calendar.current
+    lazy var dayDateFormatter: DateFormatter = {
+        let dateFormatter = DateFormatter()
+        dateFormatter.calendar = calendar
+        dateFormatter.locale = calendar.locale
+        dateFormatter.dateFormat = DateFormatter.dateFormat(
+            fromTemplate: "EEEE, MMM d, yyyy",
+            options: 0,
+            locale: calendar.locale ?? Locale.current)
+        return dateFormatter
+    }()
+    
+    lazy var dayItemClosure: (Day) -> AnyCalendarItemModel = { [weak self, calendar, dayDateFormatter] day in
+        
+        var invariantViewProperties = DayView.InvariantViewProperties.baseInteractive
+        let isSelectedStyle: Bool = day == self?.selectedDay
+        
+        if isSelectedStyle {
+            invariantViewProperties.backgroundShapeDrawingConfig.borderColor = .black
+            invariantViewProperties.backgroundShapeDrawingConfig.fillColor = .black
+            invariantViewProperties.textColor = .white
+        }
+        
+        invariantViewProperties.font = .b1M
+        let date = calendar.date(from: day.components)
+
+        return DayView.calendarItemModel(
+            invariantViewProperties: invariantViewProperties,
+            viewModel: .init(
+                dayText: "\(day.day)",
+                accessibilityLabel: date.map { dayDateFormatter.string(from: $0) },
+                accessibilityHint: nil))
+    }
+    
+    lazy var daySelectionClosure: ((Day) -> Void) = {[weak self] calendarDay in
+        
+        guard let self = self else { return }
+        
+        self.selectedDay = calendarDay
+        self.dateSelectPublisher.onNext(CalendarSelection.singleDay(self.selectedDay ?? calendarDay))
+        self.calendarView.setContent(self.makeContent())
+    }
+    
+    // MARK: - Initializer
+    
+    init() {
+        super.init(nibName: nil, bundle: nil)
+        
+        self.setLayout()
+        self.bind()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+    // MARK: - LifeCycle
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        
+        self.view.backgroundColor = .wkBlack.withAlphaComponent(0.7)
+        self.calendarView.daySelectionHandler = daySelectionClosure
+    }
+    
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        
+        self.updateBottomViewUI()
+    }
+    
+    // MARK: - Methods
+    
+    private func bind() {
+        self.resetButton.rx.tap
+            .withUnretained(self)
+            .bind { owner, _ in
+                let today = owner.calendar.day(containing: Date())
+                owner.selectedDay = today
+                owner.dateSelectPublisher.onNext(CalendarSelection.singleDay(owner.selectedDay ?? today))
+                owner.calendarView.setContent(owner.makeContent())
+                owner.calendarView.scroll(
+                    toMonthContaining: Date(),
+                    scrollPosition: .centered,
+                    animated: true)
+            }
+            .disposed(by: disposeBag)
+        
+        self.okButton.rx.tap
+            .withUnretained(self)
+            .bind { owner, _ in
+                owner.delegate?.sendSelectedSingleDay(owner.calendar.date(from: owner.selectedDay!.components) ?? Date())
+                owner.dismiss(animated: true)
+            }
+            .disposed(by: disposeBag)
+    }
+    
+    internal func setCalenderInitialDate(_ date: Date) {
+        let day = calendar.day(containing: date)
+        self.selectedDay = day
+        self.calendarView.setContent(makeContent())
+        
+        self.calendarView.scroll(
+            toMonthContaining: date,
+            scrollPosition: .centered, animated: false)
+        self.dateSelectPublisher.onNext(CalendarSelection.singleDay(self.selectedDay ?? day))
+    }
+    
+    func makeContent() -> CalendarViewContent {
+        let startDate = calendar.date(from: DateComponents(year: 2010, month: 01, day: 01))!
+        let endDate = calendar.date(from: DateComponents(year: 2100, month: 12, day: 31))!
+        
+        return CalendarViewContent(
+            calendar: calendar,
+            visibleDateRange: startDate...endDate,
+            monthsLayout: .horizontal(options: .init()))
+        .interMonthSpacing(24)
+        .verticalDayMargin(8)
+        .horizontalDayMargin(8)
+        .monthHeaderItemProvider({ month in
+            var invariantViewProperties = MonthHeaderView.InvariantViewProperties.base
+            invariantViewProperties.font = .h4B
+            return MonthHeaderView.calendarItemModel(
+                invariantViewProperties: invariantViewProperties,
+                viewModel: .init(
+                    monthText: "\(month.components.year ?? 0)년 \(month.month)월",
+                    accessibilityLabel: nil))
+        })
+        .dayItemProvider(dayItemClosure)
+    }
+    
+    internal override func setLayout() {
+        self.view.addSubviews([bottomView])
+        self.bottomView.addSubviews([okButton, resetButton, calendarView])
+        
+        self.bottomView.snp.makeConstraints { make in
+            make.bottom.equalToSuperview().offset(500 + self.bottomView.layer.cornerRadius)
+            make.leading.trailing.equalToSuperview()
+            make.height.equalTo(500 + self.bottomView.layer.cornerRadius)
+        }
+        
+        self.okButton.snp.makeConstraints { make in
+            make.top.trailing.equalToSuperview().inset(20)
+            make.width.equalTo(85)
+            make.height.equalTo(35)
+        }
+        
+        self.resetButton.snp.makeConstraints { make in
+            make.centerY.equalTo(self.okButton)
+            make.leading.equalToSuperview().inset(20)
+            make.width.equalTo(63)
+            make.height.equalTo(24)
+        }
+        
+        self.calendarView.snp.makeConstraints { make in
+            make.top.equalTo(self.okButton.snp.bottom).offset(20)
+            make.leading.trailing.equalToSuperview().inset(20)
+            make.height.equalTo(360)
+        }
+    }
+    
+    private func updateBottomViewUI() {
+        self.bottomView.snp.updateConstraints { make in
+            make.bottom.equalToSuperview().offset(self.bottomView.layer.cornerRadius)
+        }
+        
+        UIView.animate(
+            withDuration: 0.1,
+            delay: 0.0,
+            options: .curveEaseInOut,
+            animations: {
+                self.view.layoutIfNeeded()
+            })
+    }
+}

--- a/Projects/App/Sources/Screens/CalendarBottomSheet/SingleDayCalendarBottomSheetViewController.swift
+++ b/Projects/App/Sources/Screens/CalendarBottomSheet/SingleDayCalendarBottomSheetViewController.swift
@@ -13,7 +13,8 @@ import HorizonCalendar
 import RxSwift
 import SnapKit
 
-// swiftlint:type_name
+// swiftlint:disable type_name
+// swiftLint:disable blanket_disable_command
 
 protocol SingleDayCalendarBottomSheetDelegate: AnyObject {
     func sendSelectedSingleDay(_ date: Date)

--- a/Projects/App/Sources/Screens/CalendarBottomSheet/SingleDayCalendarBottomSheetViewController.swift
+++ b/Projects/App/Sources/Screens/CalendarBottomSheet/SingleDayCalendarBottomSheetViewController.swift
@@ -14,7 +14,6 @@ import RxSwift
 import SnapKit
 
 // swiftlint:disable type_name
-// swiftLint:disable function_body_length
 
 protocol SingleDayCalendarBottomSheetDelegate: AnyObject {
     func sendSelectedSingleDay(_ date: Date)
@@ -237,3 +236,5 @@ final class SingleDayCalendarBottomSheetViewController: BaseViewController {
             })
     }
 }
+
+// swiftlint:enable type_name

--- a/Projects/App/Sources/Screens/CalendarBottomSheet/SingleDayCalendarBottomSheetViewController.swift
+++ b/Projects/App/Sources/Screens/CalendarBottomSheet/SingleDayCalendarBottomSheetViewController.swift
@@ -14,7 +14,7 @@ import RxSwift
 import SnapKit
 
 // swiftlint:disable type_name
-// swiftLint:disable blanket_disable_command
+// swiftLint:disable function_body_length
 
 protocol SingleDayCalendarBottomSheetDelegate: AnyObject {
     func sendSelectedSingleDay(_ date: Date)

--- a/Projects/App/Sources/Screens/Write/WriteViewController.swift
+++ b/Projects/App/Sources/Screens/Write/WriteViewController.swift
@@ -120,6 +120,7 @@ final class WriteViewController: BaseViewController {
         self.setAbilityAddButtonAction()
         self.setAbilityCollectionView()
         self.setProjectButtonAction()
+        self.setDateButtonAction()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -220,6 +221,28 @@ final class WriteViewController: BaseViewController {
             selectProjectBottomViewController.delegate = self
             self?.present(selectProjectBottomViewController, animated: true)
         }
+    }
+    
+    private func setDateButtonAction() {
+        self.dateButton.setAction { [weak self] in
+            let dateBottomViewController = SingleDayCalendarBottomSheetViewController()
+            dateBottomViewController.modalPresentationStyle = .overFullScreen
+            dateBottomViewController.modalTransitionStyle = .crossDissolve
+            dateBottomViewController.delegate = self
+            
+            dateBottomViewController.setCalenderInitialDate(self?.dateButton.date() ?? Date())
+            
+            self?.present(dateBottomViewController, animated: true)
+        }
+    }
+}
+
+// MARK: - Extension (UICollectionViewDelegateFlowLayout)
+
+extension WriteViewController: SingleDayCalendarBottomSheetDelegate {
+    func sendSelectedSingleDay(_ date: Date) {
+        print(date)
+        self.dateButton.setDate(date: date)
     }
 }
 

--- a/Projects/App/Sources/Screens/Write/WriteViewController.swift
+++ b/Projects/App/Sources/Screens/Write/WriteViewController.swift
@@ -121,6 +121,7 @@ final class WriteViewController: BaseViewController {
         self.setAbilityCollectionView()
         self.setProjectButtonAction()
         self.setDateButtonAction()
+        self.setCloseButtonAction()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -233,6 +234,29 @@ final class WriteViewController: BaseViewController {
             dateBottomViewController.setCalenderInitialDate(self?.dateButton.date() ?? Date())
             
             self?.present(dateBottomViewController, animated: true)
+        }
+    }
+    
+    private func setCloseButtonAction() {
+        if let button = self.navigationBar.topItem?.leftBarButtonItem?.customView as? UIButton {
+            button.setAction { [weak self] in
+                let alert = UIAlertController(
+                    title: Text.closeTitle,
+                    message: Text.closeContent,
+                    preferredStyle: .alert
+                )
+                let continueAction = UIAlertAction(title: Text.continueTitle, style: .cancel) { _ in
+                    alert.dismiss(animated: true)
+                }
+                let cancelAction = UIAlertAction(title: Text.cancelTitle, style: .destructive) { _ in
+                    self?.dismiss(animated: true)
+                }
+                
+                alert.addAction(continueAction)
+                alert.addAction(cancelAction)
+                
+                self?.present(alert, animated: true)
+            }
         }
     }
 }

--- a/Projects/App/Sources/Screens/Write/WriteViewController.swift
+++ b/Projects/App/Sources/Screens/Write/WriteViewController.swift
@@ -16,11 +16,28 @@ import SnapKit
 
 final class WriteViewController: BaseViewController {
     
+    enum Text {
+        static let save = "저장"
+        static let dateLabel = "업무 날짜"
+        static let closeTitle = "기록을 취소하시겠어요?"
+        static let closeContent = "지금 나가면 작성한 내용이\n모두 사라집니다."
+        static let continueTitle = "이어쓰기"
+        static let cancelTitle = "취소하기"
+        static let projectLabel = "프로젝트"
+        static let projectButtonPlaceholder = "프로젝트명을 입력해주세요"
+        static let workLabel = "업무"
+        static let workTextFieldPlaceholder = "업무명을 입력해주세요"
+        static let abilityLabel = "역량 태그"
+        static let abilityAddButton = "역량 추가하기"
+        static let workDescriptionLabel = "업무 내용"
+        static let workDescriptionPlaceholder = "업무의 구체적인 과정과 배운 점을 남겨주세요!"
+    }
+    
     // MARK: - UIComponents
     
     private let navigationBar: WKNavigationBar = {
         let navigationBar: WKNavigationBar = WKNavigationBar()
-        navigationBar.topItem?.rightBarButtonItem = UIBarButtonItem(customView: WKNavigationButton(text: "저장"))
+        navigationBar.topItem?.rightBarButtonItem = UIBarButtonItem(customView: WKNavigationButton(text: Text.save))
         navigationBar.topItem?.leftBarButtonItem = UIBarButtonItem(customView: WKNavigationButton(image: Image.wkX))
         return navigationBar
     }()
@@ -34,7 +51,7 @@ final class WriteViewController: BaseViewController {
     
     private let dateLabel: WKStarLabel = {
         let label: WKStarLabel = WKStarLabel()
-        label.text = "업무 날짜"
+        label.text = Text.dateLabel
         return label
     }()
     
@@ -42,31 +59,31 @@ final class WriteViewController: BaseViewController {
     
     private let projectLabel: WKStarLabel = {
         let label: WKStarLabel = WKStarLabel()
-        label.text = "프로젝트"
+        label.text = Text.projectLabel
         return label
     }()
     
     private let projectButton: WKTextFieldStyleButton = {
         let button: WKTextFieldStyleButton = WKTextFieldStyleButton(style: .defaultStyle)
-        button.setPlaceholder(text: "프로젝트명을 입력해주세요")
+        button.setPlaceholder(text: Text.projectButtonPlaceholder)
         return button
     }()
     
     private let workLabel: WKStarLabel = {
         let label: WKStarLabel = WKStarLabel()
-        label.text = "업무"
+        label.text = Text.workLabel
         return label
     }()
     
     private let workTextField: WKTextField = {
         let textField: WKTextField = WKTextField()
-        textField.placeholder = "업무명을 입력해주세요"
+        textField.placeholder = Text.workTextFieldPlaceholder
         return textField
     }()
     
     private let abilityLabel: WKStarLabel = {
         let label: WKStarLabel = WKStarLabel()
-        label.text = "역량 태그"
+        label.text = Text.abilityLabel
         return label
     }()
     
@@ -75,19 +92,19 @@ final class WriteViewController: BaseViewController {
     
     private let abilityAddButton: WKAbilityAddButton = {
         let button: WKAbilityAddButton = WKAbilityAddButton()
-        button.setTitle("역량 추가하기", for: .normal)
+        button.setTitle(Text.abilityAddButton, for: .normal)
         return button
     }()
     
     private let workDescriptionLabel: UILabel = {
         let label: UILabel = UILabel()
-        label.text = "업무 내용"
+        label.text = Text.workDescriptionLabel
         return label
     }()
     
     private let workDescriptionTextView: WKTextView = {
         let textView: WKTextView = WKTextView()
-        textView.setPlaceholder(text: "업무의 구체적인 과정과 배운 점을 남겨주세요!")
+        textView.setPlaceholder(text: Text.workDescriptionPlaceholder)
         return textView
     }()
     

--- a/Projects/DesignSystem/Sources/UIComponents/Buttons/WKTextFieldStyleButton.swift
+++ b/Projects/DesignSystem/Sources/UIComponents/Buttons/WKTextFieldStyleButton.swift
@@ -26,6 +26,7 @@ public class WKTextFieldStyleButton: UIButton {
     
     private let textField: WKTextField = WKTextField()
     private let calendarImageView: UIImageView = UIImageView(image: Image.wkCalendar.withRenderingMode(.alwaysOriginal))
+    private var selectedDate: Date = Date()
     
     // MARK: Initializer
     
@@ -43,6 +44,7 @@ public class WKTextFieldStyleButton: UIButton {
     // MARK: - Methods
     
     public func setDate(date: Date) {
+        self.selectedDate = date
         self.textField.text = date.toString(type: .dot)
     }
     
@@ -52,6 +54,10 @@ public class WKTextFieldStyleButton: UIButton {
     
     public func setText(text: String) {
         self.textField.text = text
+    }
+    
+    public func date() -> Date {
+        return self.selectedDate
     }
 }
 


### PR DESCRIPTION
## 관련 이슈
- Resolved: #93

## 작업 내용
- 기록하기 뷰에서 사용되는 "단일 날짜 선택"을 위한 캘린더 바텀시트인 `SingleDayCalendarBottomSheetViewController` 구현
  * 단일 날짜 선택 구현
  * 재설정 및 확인 구현
  * 해당 뷰 UI 요구사항에 맞도록 구현
  thanks to @hyesuuou ,,,
  => 캘린더만 따로 빼서 컴포넌트화가 좋아 보이지만 ,, 시간이 없는 관계로 ㅡ,, 이렇게라더 .. 그리고 캘린더 코드를 잘 모르겠숴여...
- 기록하기 취소 시 나오는 Alert 구현
## 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


https://user-images.githubusercontent.com/43312096/230227065-3b6268e2-32d0-4fad-93c2-a9ede2bfe430.mp4

<img width="487" alt="스크린샷 2023-04-06 07 39 23" src="https://user-images.githubusercontent.com/43312096/230227196-13168586-a928-4d9c-a391-1eefbfc087ee.png">



<!-- 아 맞다! Assignee, Reviewer, Label 설정! 😇 -->
