### PR TITLE
Fix: 역량태그 선택 해제 시 에러 처리

### DIFF
--- a/Projects/App/Sources/Screens/Write/PickAbility/PickAbilityBottomViewController.swift
+++ b/Projects/App/Sources/Screens/Write/PickAbility/PickAbilityBottomViewController.swift
@@ -275,7 +275,7 @@ extension PickAbilityBottomViewController: UITableViewDelegate {
             var selectedAbility: Ability = Ability(
                 id: 0,
                 name: "",
-                type: ""
+                type: "hard"
             )
             if tableView == self.hardAbilityTableView {
                 selectedAbility = hardAbilityList[indexPath.row]


### PR DESCRIPTION
## 관련 이슈
- Resolved: #119

## 작업 내용
- 역량 모델을 Ability로 교체하면서 태그 타입이 지정되어 있지 않아 생기던 오류 수정

<!-- 아 맞다! Assignee, Reviewer, Label 설정! 😇 -->
