### PR TITLE
Fix: 워킷 상세보기 navi 버그 수정

### DIFF
--- a/Projects/App/Sources/Screens/WorkDetail/WorkDetailViewController.swift
+++ b/Projects/App/Sources/Screens/WorkDetail/WorkDetailViewController.swift
@@ -118,7 +118,6 @@ final class WorkDetailViewController: BaseViewController {
         super.viewDidLoad()
         
         self.setNavigationBar()
-        self.setBackButtonAction()
         self.setMenuButtonAction()
         self.setScrollView()
         self.setLayout()
@@ -134,20 +133,12 @@ final class WorkDetailViewController: BaseViewController {
     // MARK: Methods
     
     private func setNavigationBar() {
-        self.navigationController?.navigationBar.topItem?.rightBarButtonItem = UIBarButtonItem(customView: WKNavigationButton(image: Image.wkKebapA))
-        self.navigationController?.navigationBar.topItem?.leftBarButtonItem = UIBarButtonItem(customView: WKNavigationButton(image: Image.wkArrowBig))
-    }
-    
-    private func setBackButtonAction() {
-        if let button = self.navigationController?.navigationBar.topItem?.leftBarButtonItem?.customView as? UIButton {
-            button.setAction { [weak self] in
-                self?.navigationController?.popViewController(animated: true)
-            }
-        }
+        let rightButtonItem = UIBarButtonItem(customView: WKNavigationButton(image: Image.wkKebapA))
+        self.navigationItem.rightBarButtonItem = rightButtonItem
     }
     
     private func setMenuButtonAction() {
-        if let button = self.navigationController?.navigationBar.topItem?.rightBarButtonItem?.customView as? UIButton {
+        if let button = self.navigationItem.rightBarButtonItem?.customView as? UIButton {
             button.setAction { [weak self] in
                 let actionSheet = UIAlertController(
                     title: nil,


### PR DESCRIPTION
## 관련 이슈
- Resolved: #136

## 작업 내용
- 워킷 상세보기에서 사용되던 navigation bar item 방식을 변경하였습니다... @yunyezl 
  - 모달 뷰에서 쓰던 코드.. 그대로 쓰다보니 바보같이 쓴듯요 하하...
  - 저는 워킷 상세보기 갔다가 pop 잘 되는데 그래도 안되면 말해주세요..!!!

## 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->


https://user-images.githubusercontent.com/43312096/235367100-8afbf318-c529-48a8-9375-2ba809c5604b.MP4



<!-- 아 맞다! Assignee, Reviewer, Label 설정! 😇 -->
