### PR TITLE
Fix: 기록하기 시 시간 잘못 들어가는 버그 수정

### DIFF
--- a/Projects/App/Sources/Screens/Write/WriteViewController.swift
+++ b/Projects/App/Sources/Screens/Write/WriteViewController.swift
@@ -321,7 +321,7 @@ final class WriteViewController: BaseViewController {
             title: self.workTextField.text ?? "",
             projectId: self.selectedProjectId,
             description: self.workDescriptionTextView.text,
-            date: self.dateButton.date(),
+            date: (self.dateButton.date().toString(type: .dot).toDate(type: .dot) ?? Date()) + 60,
             abilityIds: self.createAbilityIdList(
                 hardList: self.selectedHardAbilityList,
                 softList: self.selectedSoftAbilityList
@@ -447,7 +447,6 @@ final class WriteViewController: BaseViewController {
 
 extension WriteViewController: SingleDayCalendarBottomSheetDelegate {
     func sendSelectedSingleDay(_ date: Date) {
-        print(date)
         self.dateButton.setDate(date: date)
     }
 }

--- a/Projects/DesignSystem/Sources/UIComponents/Buttons/WKTextFieldStyleButton.swift
+++ b/Projects/DesignSystem/Sources/UIComponents/Buttons/WKTextFieldStyleButton.swift
@@ -77,7 +77,7 @@ extension WKTextFieldStyleButton {
         
         if style == Style.withCalendarStyle {
             self.setCalendarImageLayout()
-            self.setDate(date: Date())
+            self.setDate(date: Date().toString(type: .dot).toDate(type: .dot) ?? Date())
         }
     }
     


### PR DESCRIPTION
## 관련 이슈
- Resolved: #179

## 작업 내용
- 기록하기 보낼 때 다 한국 시간 + 1분으로 맞춰서 보냄

## 스크린샷
<!-- gif or mp4 용량 제한이 있는데... 용량 넘어가면 슬랙으로 보내 주세요. -->



<!-- 아 맞다! Assignee, Reviewer, Label 설정! 😇 -->
